### PR TITLE
Configure TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+lib/
 node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,35 @@
+{
+	"name": "dr-devdeps",
+	"version": "0.2.0",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "dr-devdeps",
+			"version": "0.2.0",
+			"license": "MIT",
+			"dependencies": {
+				"typescript": "5.0.4"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+			"integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=12.20"
+			}
+		}
+	},
+	"dependencies": {
+		"typescript": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+			"integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dr-devdeps",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "",
 	"main": "index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
 	"main": "index.js",
 	"scripts": {
 		"// build": "Scripts related to building and compiling the package.",
+		"prebuild": "node ./scripts/prebuild.js",
 		"build:cjs": "tsc --project ./src/tsconfig.cjs.json",
 		"build:esm": "tsc --project ./src/tsconfig.esm.json",
 		"build": "npm run build:cjs & npm run build:esm",
+		"postbuild": "node ./scripts/postbuild.js",
 		"test": "echo \"Error: no test specified\" && exit 1",
 		"typecheck": "tsc --noEmit --project ./src/tsconfig.esm.json",
 		"validate": "npm run typecheck"

--- a/package.json
+++ b/package.json
@@ -4,11 +4,20 @@
 	"description": "",
 	"main": "index.js",
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
+		"// build": "Scripts related to building and compiling the package.",
+		"build:cjs": "tsc --project ./src/tsconfig.cjs.json",
+		"build:esm": "tsc --project ./src/tsconfig.esm.json",
+		"build": "npm run build:cjs & npm run build:esm",
+		"test": "echo \"Error: no test specified\" && exit 1",
+		"typecheck": "tsc --noEmit --project ./src/tsconfig.esm.json",
+		"validate": "npm run typecheck"
 	},
 	"keywords": [],
 	"author": "Dustin Ruetz",
 	"license": "MIT",
 	"repository": "https://github.com/dustin-ruetz/dr-devdeps.git",
-	"type": "module"
+	"type": "module",
+	"dependencies": {
+		"typescript": "5.0.4"
+	}
 }

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,7 +1,7 @@
 import {appendFile, copyFile, readdir, rename} from "node:fs/promises";
 
 const postbuild = async () => {
-	// Copy the uncompiled non-TypeScript files from src/config/ to lib/
+	// Copy the uncompiled non-TypeScript files from src/ to lib/
 	const srcFiles = await readdir("src/");
 
 	const jsonFiles = srcFiles.filter((file) => file.includes(".json"));

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,0 +1,14 @@
+import {appendFile, copyFile, readdir, rename} from "node:fs/promises";
+
+const postbuild = async () => {
+	// Copy the uncompiled non-TypeScript files from src/config/ to lib/
+	const srcFiles = await readdir("src/");
+
+	const jsonFiles = srcFiles.filter((file) => file.includes(".json"));
+
+	const filesToCopy = [...jsonFiles];
+	filesToCopy.forEach(async (file) => {
+		await copyFile(`src/${file}`, `lib/${file}`);
+	});
+};
+postbuild();

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -1,0 +1,9 @@
+import {rm} from "node:fs/promises";
+
+const prebuild = async () => {
+	// Delete the lib/ directory.
+	// The following line simulates behavior of the Unix `rm -rf directoryName/` command,
+	// but since this is a Node script this operation can be run in a cross-platform way.
+	await rm("lib/", {force: true, recursive: true});
+};
+prebuild();

--- a/src/tsconfig.base.json
+++ b/src/tsconfig.base.json
@@ -1,0 +1,35 @@
+// https://www.typescriptlang.org/tsconfig
+// https://www.typescriptlang.org/tsconfig#root-fields
+// https://github.com/tsconfig/bases
+{
+	"include": ["../src/"],
+	// https://www.typescriptlang.org/tsconfig#compiler-options
+	"compilerOptions": {
+		"allowJs": false,
+		"allowUnreachableCode": false,
+		"allowUnusedLabels": false,
+		"esModuleInterop": true,
+		"exactOptionalPropertyTypes": true,
+		"forceConsistentCasingInFileNames": true,
+		"jsx": "react",
+		// Set `"moduleResolution": "node"` to:
+		// 1) prevent tsc from checking /node_modules/, and
+		// 2) to allow for .ts/.tsx file imports without file extensions
+		"moduleResolution": "node",
+		"noEmitOnError": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"noUncheckedIndexedAccess": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"removeComments": true,
+		"resolveJsonModule": true,
+		"strict": true,
+		// Excerpt from https://www.typescriptlang.org/tsconfig#target on not using `"target": "esnext"`:
+		// > The special `ESNext` value refers to the highest version your version of TypeScript supports.
+		// > This setting should be used with caution, since it doesn’t mean the same thing between
+		// > different TypeScript versions and can make upgrades less predictable.
+		"target": "es2022"
+	}
+}

--- a/src/tsconfig.cjs.json
+++ b/src/tsconfig.cjs.json
@@ -1,0 +1,17 @@
+{
+	"extends": "./tsconfig.base.json",
+	"compilerOptions": {
+		// Set `"isolatedModules": true` due to setting `"verbatimModuleSyntax": false`.
+		"isolatedModules": true,
+		"module": "commonjs",
+		// Set `"moduleResolution": "node"` to:
+		// 1) prevent tsc from checking /node_modules/, and
+		// 2) to allow for .ts/.tsx file imports without file extensions
+		// "moduleResolution": "node",
+		"outDir": "../lib/cjs/",
+		// Set `"verbatimModuleSyntax": false` to prevent the following error:
+		// > TS1287: A top-level 'export' modifier cannot be used on value declarations
+		// > in a CommonJS module when 'verbatimModuleSyntax' is enabled.
+		"verbatimModuleSyntax": false
+	}
+}

--- a/src/tsconfig.esm.json
+++ b/src/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.base.json",
+	"compilerOptions": {
+		"module": "esnext",
+		// "moduleResolution": "nodenext",
+		"outDir": "../lib/esm/",
+		"verbatimModuleSyntax": true
+	}
+}


### PR DESCRIPTION
Summary of changes:

- Install `typescript` as a dependency.
- Add NPM scripts: `build`, `typecheck` and `validate`.
  - The `build` script is comprised of the `build:cjs` and `build:esm` NPM scripts, and it runs these two in parallel.
- Add Node scripts: `prebuild` and `postbuild`.
  - `prebuild` deletes the `lib/` directory.
  - `postbuild` copies the tsconfig.*.json files from `src/` to `lib/`.
- .gitignore the compiled `lib/` directory that is created by the `build` script.
- Manually bump the package.json version number to `0.2.0`.