### PR TITLE
Flatten `lib/` directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dr-devdeps",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dr-devdeps",
-			"version": "0.4.0",
+			"version": "0.5.0",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"// postinstall": "After dependencies are installed to ./node_modules/, build the package then validate the codebase.",
 		"postinstall": "npm run build && npm run validate",
 		"// test": "Scripts for testing the codebase.",
-		"test": "jest --config ./lib/esm/.jestrc.js",
+		"test": "jest --config ./lib/.jestrc.mjs",
 		"test:clearcache": "jest --clearCache",
 		"test:coverage": "npm run test -- --coverage",
 		"test:watch": "npm run test -- --watch",
@@ -40,5 +40,5 @@
 		"typescript": "5.0.4"
 	},
 	"// config": "Configuration for Prettier.",
-	"prettier": "./lib/cjs/.prettierrc.cjs"
+	"prettier": "./lib/.prettierrc.cjs"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dr-devdeps",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"description": "",
 	"main": "index.js",
 	"scripts": {

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,4 +1,4 @@
-import {appendFile, copyFile, readdir, rename} from "node:fs/promises";
+import {appendFile, copyFile, readdir, rename, rm} from "node:fs/promises";
 
 // Originally I wanted to use async/await with the forEach() function, but this doesn't always
 // work the way that I expect it to. MDN suggests using `for of` as a succinct alternative.
@@ -22,11 +22,21 @@ const appendPrettierConfigFile = async () => {
 		"module.exports = exports.prettierConfig;\n",
 	);
 };
+
+const copyCompiledFilesToLib = async () => {
+	const cjsFiles = await readdir("lib/cjs/");
+	for (const file of cjsFiles) {
+		await copyFile(`lib/cjs/${file}`, `lib/${file}`);
+	}
+
+	const esmFiles = await readdir("lib/esm/");
+	for (const file of esmFiles) {
+		await copyFile(`lib/esm/${file}`, `lib/${file}`);
 	}
 };
 
 /** Copy the uncompiled non-TypeScript files from src/ to lib/ */
-const copyFiles = async () => {
+const copyUncompiledFilesToLib = async () => {
 	const srcFiles = await readdir("src/");
 
 	const dotFiles = srcFiles.filter((file) => {
@@ -42,6 +52,12 @@ const copyFiles = async () => {
 	}
 };
 
+/** Delete the lib/cjs/ and lib/esm/ directories. */
+const deleteDirectoriesInLib = async () => {
+	await rm("lib/cjs/", {force: true, recursive: true});
+	await rm("lib/esm/", {force: true, recursive: true});
+};
+
 /** Rename files in lib/cjs/ by changing their extensions from .js to .cjs */
 const renameFilesInLibCJS = async () => {
 	const cjsFiles = await readdir("lib/cjs/");
@@ -50,8 +66,22 @@ const renameFilesInLibCJS = async () => {
 		await rename(`lib/cjs/${fileName}.js`, `lib/cjs/${fileName}.cjs`);
 	}
 };
+/** Rename files in lib/esm/ by changing their extensions from .js to .mjs */
+const renameFilesInLibESM = async () => {
+	const esmFiles = await readdir("lib/esm/");
+	const esmFileNames = esmFiles.map((file) => file.replace(".js", ""));
+	for (const fileName of esmFileNames) {
+		await rename(`lib/esm/${fileName}.js`, `lib/esm/${fileName}.mjs`);
+	}
+};
 
 const postbuild = async () => {
+	// Make use of `Promise.all` to kick off multiple asynchronous operations simultaneously
+	// and wait for all of them to resolve before proceeding to the next operation.
+	await Promise.all([renameFilesInLibCJS(), renameFilesInLibESM()]);
 	await appendPrettierConfigFile();
+	await Promise.all([copyCompiledFilesToLib(), copyUncompiledFilesToLib()]);
+	// Delete lib/cjs/ and lib/esm/ now that their child files have been copied to the lib/ directory.
+	await deleteDirectoriesInLib();
 };
 postbuild();

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -4,29 +4,24 @@ import {appendFile, copyFile, readdir, rename} from "node:fs/promises";
 // work the way that I expect it to. MDN suggests using `for of` as a succinct alternative.
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises#composition
 
-/**
- * Append files in lib/cjs/ with a `module.exports` line in order to:
- * 1. simplify the codebase by having everything written in ESModule syntax,
- * 2. export both CommonJS- and ESModule-compatible code from their respective lib/ directories, and
- * 3. use tsc for building/compiling without needing to install additional dependencies.
- */
-const appendFilesInLibCJS = async () => {
-	const cjsFiles = await readdir("lib/cjs/");
+// Append certain files in lib/cjs/ with a `module.exports` line in order to:
+// 1. simplify the codebase by keeping everything in src/ written in ESModule syntax,
+// 2. export both CommonJS- and ESModule-compatible code from the lib/ directory, and
+// 3. use tsc for building/compiling without needing to install additional dependencies.
 
-	for (const file of cjsFiles) {
-		switch (file) {
-			// Note that Prettier requires a CommonJS file using `module.exports` in its current v2 iteration, but if this changes
-			// in v3 then it may be possible to remove all CommonJS-related code/compilation entirely from this repo.
-			// Excerpt from https://prettier.io/docs/en/configuration.html:
-			// > You can configure Prettier via a `.prettierrc.cjs` file that exports an object using `module.exports`.
-			case ".prettierrc.cjs": {
-				await appendFile(
-					"lib/cjs/.prettierrc.cjs",
-					"module.exports = exports.prettierConfig;\n",
-				);
-				break;
-			}
-		}
+/**
+ * Note that Prettier requires a CommonJS file using `module.exports` in its current v2 iteration, but if this changes
+ * in v3 then it may be possible to remove all CommonJS-related code/compilation entirely from this repo.
+ *
+ * Excerpt from https://prettier.io/docs/en/configuration.html:
+ * > You can configure Prettier via a `.prettierrc.cjs` file that exports an object using `module.exports`.
+ */
+const appendPrettierConfigFile = async () => {
+	await appendFile(
+		"lib/cjs/.prettierrc.cjs",
+		"module.exports = exports.prettierConfig;\n",
+	);
+};
 	}
 };
 
@@ -57,8 +52,6 @@ const renameFilesInLibCJS = async () => {
 };
 
 const postbuild = async () => {
-	await renameFilesInLibCJS();
-	await appendFilesInLibCJS();
-	await copyFiles();
+	await appendPrettierConfigFile();
 };
 postbuild();

--- a/src/.jestrc.ts
+++ b/src/.jestrc.ts
@@ -26,7 +26,7 @@ const jestConfig: Config = {
 	 * > using TypeScript, you may want to consider moving "ts" and/or "tsx" to the beginning of the array.
 	 */
 	moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
-	rootDir: "../../src/",
+	rootDir: "../src/",
 	/**
 	 * Explicitly declare either `"node"|"jsdom"` as the testing environment for each repo that extends this Jest config.
 	 *
@@ -38,7 +38,7 @@ const jestConfig: Config = {
 	transform: {
 		[binaryFileExtensions.getTransformRegExp()]:
 			// Set the path to the transformer relative to the Jest <rootDir>.
-			"../lib/esm/jest-binary-file-transformer.js",
+			"../lib/jest-binary-file-transformer.mjs",
 		".(ts|tsx)": [
 			"ts-jest",
 			// The below config object is adapted from the ts-jest "jest-esm-isolated" example:

--- a/src/.prettierignore
+++ b/src/.prettierignore
@@ -2,9 +2,9 @@ build/
 coverage/
 dist/
 lib/
-# Ignore the config dotfiles in lib/cjs and lib/esm/ to prevent warnings and errors when running the `format` scripts.
-# TODO: Figure out why lib/cjs/ and lib/esm/ aren't being ignored even though they're both children of the lib/ directory.
-cjs/
-esm/
 node_modules/
 www/
+# Ignore the .cjs and .mjs file extensions to prevent warnings and errors when running the `format` scripts.
+# TODO: Figure out why these files aren't being ignored even though they're all children of the lib/ directory.
+*.cjs
+*.mjs


### PR DESCRIPTION
Building this package's files to output into the `lib/` directory simplifies:

1. How the package's files are referenced by consuming repos; and 
2. How the file-relative paths are resolved in the various config files.
  - New implementation: package files go from `src/` to `lib/`. Easy to understand because both directories are only one `../` away from each other.
  - Old implementation: package files go from `src/` to `lib/cjs/` and `lib/esm/`. This complicates file-relative paths when comparing source files to compiled files.

Summary of changes:
- Update the file-relative paths in the `.jestrc.ts`/`.prettierignore` config files and in `package.json`.
- Update the `postbuild` script with how the `lib/` directory should be handled.
  - Rename all files in `lib/cjs/` with the `.cjs` file extension.
  - Rename all files in `lib/esm/` with the `.mjs` file extension.
  - Copy all compiled files from both `lib/cjs/` and `lib/esm` to the `lib/` directory.
  - Copy all uncompiled files from `src/` to the `lib/` directory.
  - Delete the `lib/cjs/` and `lib/esm/` directories.
- Manually bump the `package.json` version number to `0.5.0`.