### PR TITLE
Test build scripts

### DIFF
--- a/scripts/__tests__/postbuild.test.js
+++ b/scripts/__tests__/postbuild.test.js
@@ -1,0 +1,28 @@
+import {appendPrettierConfigFile} from "../utils/appendPrettierConfigFile.js";
+import {copyCompiledFilesToLib} from "../utils/copyCompiledFilesToLib.js";
+import {copyUncompiledFilesToLib} from "../utils/copyUncompiledFilesToLib.js";
+import {deleteDirectoriesInLib} from "../utils/deleteDirectoriesInLib.js";
+import {renameFilesInLibCJS} from "../utils/renameFilesInLibCJS.js";
+import {renameFilesInLibESM} from "../utils/renameFilesInLibESM.js";
+import {postbuild} from "../postbuild";
+
+// Mock out everything to ensure that the code inside these imported modules isn't actually called.
+jest.mock("../utils/appendPrettierConfigFile.js");
+jest.mock("../utils/copyCompiledFilesToLib.js");
+jest.mock("../utils/copyUncompiledFilesToLib.js");
+jest.mock("../utils/deleteDirectoriesInLib.js");
+jest.mock("../utils/renameFilesInLibCJS.js");
+jest.mock("../utils/renameFilesInLibESM.js");
+
+test("it runs all of the necessary post-build file system operations", async () => {
+	await postbuild();
+
+	// List the file system operations in the same order that they're called
+	// in `postbuild`, and verify that each one is called only once.
+	expect(renameFilesInLibCJS).toHaveBeenCalledTimes(1);
+	expect(renameFilesInLibESM).toHaveBeenCalledTimes(1);
+	expect(appendPrettierConfigFile).toHaveBeenCalledTimes(1);
+	expect(copyCompiledFilesToLib).toHaveBeenCalledTimes(1);
+	expect(copyUncompiledFilesToLib).toHaveBeenCalledTimes(1);
+	expect(deleteDirectoriesInLib).toHaveBeenCalledTimes(1);
+});

--- a/scripts/__tests__/prebuild.test.js
+++ b/scripts/__tests__/prebuild.test.js
@@ -1,12 +1,6 @@
 import {rm} from "node:fs/promises";
 import {prebuild} from "../prebuild";
 
-// Excerpt from https://jestjs.io/docs/configuration#automock-boolean:
-// > Node.js core modules, like `fs`, are not mocked by default. They can be mocked explicitly, like `jest.mock("fs")`.
-jest.mock("node:fs/promises", () => ({
-	rm: jest.fn(),
-}));
-
 test("it removes the lib/ directory with the force and recursive options", async () => {
 	await prebuild();
 

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,87 +1,27 @@
-import {appendFile, copyFile, readdir, rename, rm} from "node:fs/promises";
+// These imports are ESModule files, so specifying the ".js" file extension is required.
+import {appendPrettierConfigFile} from "./utils/appendPrettierConfigFile.js";
+import {copyCompiledFilesToLib} from "./utils/copyCompiledFilesToLib.js";
+import {copyUncompiledFilesToLib} from "./utils/copyUncompiledFilesToLib.js";
+import {deleteDirectoriesInLib} from "./utils/deleteDirectoriesInLib.js";
+import {renameFilesInLibCJS} from "./utils/renameFilesInLibCJS.js";
+import {renameFilesInLibESM} from "./utils/renameFilesInLibESM.js";
 
-// Originally I wanted to use async/await with the forEach() function, but this doesn't always
-// work the way that I expect it to. MDN suggests using `for of` as a succinct alternative.
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises#composition
-
-// Append certain files in lib/cjs/ with a `module.exports` line in order to:
-// 1. simplify the codebase by keeping everything in src/ written in ESModule syntax,
-// 2. export both CommonJS- and ESModule-compatible code from the lib/ directory, and
-// 3. use tsc for building/compiling without needing to install additional dependencies.
-
-/**
- * Note that Prettier requires a CommonJS file using `module.exports` in its current v2 iteration, but if this changes
- * in v3 then it may be possible to remove all CommonJS-related code/compilation from this repository entirely.
- *
- * Excerpt from https://prettier.io/docs/en/configuration.html:
- * > You can configure Prettier via a `.prettierrc.cjs` file that exports an object using `module.exports`.
- */
-const appendPrettierConfigFile = async () => {
-	await appendFile(
-		"lib/cjs/.prettierrc.cjs",
-		"module.exports = exports.prettierConfig;\n",
-	);
-};
-
-const copyCompiledFilesToLib = async () => {
-	const cjsFiles = await readdir("lib/cjs/");
-	for (const file of cjsFiles) {
-		await copyFile(`lib/cjs/${file}`, `lib/${file}`);
-	}
-
-	const esmFiles = await readdir("lib/esm/");
-	for (const file of esmFiles) {
-		await copyFile(`lib/esm/${file}`, `lib/${file}`);
-	}
-};
-
-/** Copy the uncompiled non-TypeScript files from src/ to lib/ */
-const copyUncompiledFilesToLib = async () => {
-	const srcFiles = await readdir("src/");
-
-	const dotFiles = srcFiles.filter((file) => {
-		if (file[0] === "." && !file.includes(".ts")) {
-			return file;
-		}
-	});
-	const jsonFiles = srcFiles.filter((file) => file.includes(".json"));
-
-	const filesToCopy = [...dotFiles, ...jsonFiles];
-	for (const file of filesToCopy) {
-		await copyFile(`src/${file}`, `lib/${file}`);
-	}
-};
-
-/** Delete the lib/cjs/ and lib/esm/ directories. */
-const deleteDirectoriesInLib = async () => {
-	await rm("lib/cjs/", {force: true, recursive: true});
-	await rm("lib/esm/", {force: true, recursive: true});
-};
-
-/** Rename files in lib/cjs/ by changing their extensions from .js to .cjs */
-const renameFilesInLibCJS = async () => {
-	const cjsFiles = await readdir("lib/cjs/");
-	const cjsFileNames = cjsFiles.map((file) => file.replace(".js", ""));
-	for (const fileName of cjsFileNames) {
-		await rename(`lib/cjs/${fileName}.js`, `lib/cjs/${fileName}.cjs`);
-	}
-};
-/** Rename files in lib/esm/ by changing their extensions from .js to .mjs */
-const renameFilesInLibESM = async () => {
-	const esmFiles = await readdir("lib/esm/");
-	const esmFileNames = esmFiles.map((file) => file.replace(".js", ""));
-	for (const fileName of esmFileNames) {
-		await rename(`lib/esm/${fileName}.js`, `lib/esm/${fileName}.mjs`);
-	}
-};
-
-const postbuild = async () => {
+export const postbuild = async () => {
 	// Make use of `Promise.all` to kick off multiple asynchronous operations simultaneously
-	// and wait for all of them to resolve before proceeding to the next operation.
+	// and wait for all of them to resolve before proceeding to the next block of operations.
 	await Promise.all([renameFilesInLibCJS(), renameFilesInLibESM()]);
+	// Append certain files in lib/cjs/ with a `module.exports` line in order to:
+	// 1. simplify the codebase by keeping everything in src/ written in ESModule syntax,
+	// 2. export both CommonJS- and ESModule-compatible code from the lib/ directory, and
+	// 3. use tsc for building/compiling without needing to install additional dependencies.
 	await appendPrettierConfigFile();
 	await Promise.all([copyCompiledFilesToLib(), copyUncompiledFilesToLib()]);
 	// Delete lib/cjs/ and lib/esm/ now that their child files have been copied to the lib/ directory.
 	await deleteDirectoriesInLib();
 };
-postbuild();
+
+// Refer to scripts/prebuild.js file for why these lines are being excluded from the test coverage report.
+/* istanbul ignore next */
+if (process.env.NODE_ENV !== "test") {
+	postbuild();
+}

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -19,8 +19,8 @@ export const prebuild = async () => {
 // Excerpt from https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines:
 // > There may be some sections of your codebase that you wish to purposefully exclude
 // > from coverage tracking, to do so you can use the following parsing hints:
-// > `/* istanbul ignore next */`: ignore the next _thing_ in the source-code
-// > (functions, if statements, classes, you name it).
+// > - `/* istanbul ignore next */`: ignore the next _thing_ in the source-code
+// >   (functions, if statements, classes, you name it).
 /* istanbul ignore next */
 if (process.env.NODE_ENV !== "test") {
 	prebuild();

--- a/scripts/utils/__mocks__/files.js
+++ b/scripts/utils/__mocks__/files.js
@@ -1,0 +1,26 @@
+/** Mock filenames compiled from src/ to lib/cjs/ and lib/esm/ */
+export const compiledFiles = [
+	".jestrc.js",
+	".prettierrc.js",
+	"jestMockNodeCoreModules.js",
+	"jestTransformerBabelJest.js",
+	"jestTransformerBinaryFile.js",
+];
+
+/** Mock filenames after the `renameFilesInLibCJS` operation completes. */
+export const cjsFiles = compiledFiles.map((file) =>
+	file.replace(".js", ".cjs"),
+);
+
+/** Mock filenames after the `renameFilesInLibESM` operation completes. */
+export const esmFiles = compiledFiles.map((file) =>
+	file.replace(".js", ".mjs"),
+);
+
+/** Mock filenames of the non-TypeScript files copied from src/ to lib/ */
+export const uncompiledFiles = [
+	".prettierignore",
+	"tsconfig.base.json",
+	"tsconfig.cjs.json",
+	"tsconfig.esm.json",
+];

--- a/scripts/utils/__tests__/appendPrettierConfigFile.test.js
+++ b/scripts/utils/__tests__/appendPrettierConfigFile.test.js
@@ -1,0 +1,13 @@
+import {appendFile} from "node:fs/promises";
+import {appendPrettierConfigFile} from "../appendPrettierConfigFile.js";
+
+test("it appends the Prettier config file to make it work as a CommonJS export", async () => {
+	await appendPrettierConfigFile();
+
+	// Verify that `appendFile` was called once and with the correct arguments.
+	expect(appendFile).toHaveBeenCalledTimes(1);
+	expect(appendFile).toHaveBeenCalledWith(
+		"lib/cjs/.prettierrc.cjs",
+		"module.exports = exports.prettierConfig;\n",
+	);
+});

--- a/scripts/utils/__tests__/copyCompiledFilesToLib.test.js
+++ b/scripts/utils/__tests__/copyCompiledFilesToLib.test.js
@@ -1,0 +1,64 @@
+import {copyFile, readdir} from "node:fs/promises";
+import {cjsFiles, esmFiles} from "../__mocks__/files.js";
+import {copyCompiledFilesToLib} from "../copyCompiledFilesToLib.js";
+
+// const compiledFiles = [
+// 	".jestrc",
+// 	".prettierrc",
+// 	"jestMockNodeCoreModules",
+// 	"jestTransformerBabelJest",
+// 	"jestTransformerBinaryFile",
+// ];
+
+// `readdir` is already equal to a mocked `jest.fn()` here due to the Jest config
+// `setupFilesAfterEnv` option and the lib/jestMockNodeCoreModules.mjs file, so just use
+// `mockImplementation` to mock out its return values based on the `path` argument.
+readdir.mockImplementation((path) => {
+	switch (path) {
+		case "lib/cjs/":
+			return cjsFiles;
+		case "lib/esm/":
+			return esmFiles;
+		// case "lib/cjs/": {
+		// const cjsFiles = compiledFiles.map((file) => `${file}.cjs`);
+		// return cjsFiles;
+		// }
+		// case "lib/esm/": {
+		// const esmFiles = compiledFiles.map((file) => `${file}.mjs`);
+		// return esmFiles;
+		// }
+	}
+});
+
+test("it copies the compiled files from lib/cjs/ and lib/esm/ to lib/", async () => {
+	await copyCompiledFilesToLib();
+
+	// Verify that `readdir` was called twice and on the correct directories.
+	expect(readdir).toHaveBeenCalledTimes(2);
+	expect(readdir).toHaveBeenNthCalledWith(1, "lib/cjs/");
+	expect(readdir).toHaveBeenNthCalledWith(2, "lib/esm/");
+
+	// Verify that `copyFile` was called once per item in both `cjsFiles` and `esmFiles`.
+	expect(copyFile).toHaveBeenCalledTimes(10);
+	// Verify that a sampling of `copyFile` calls received the correct arguments.
+	expect(copyFile).toHaveBeenNthCalledWith(
+		1,
+		"lib/cjs/.jestrc.cjs",
+		"lib/.jestrc.cjs",
+	);
+	expect(copyFile).toHaveBeenNthCalledWith(
+		5,
+		"lib/cjs/jestTransformerBinaryFile.cjs",
+		"lib/jestTransformerBinaryFile.cjs",
+	);
+	expect(copyFile).toHaveBeenNthCalledWith(
+		6,
+		"lib/esm/.jestrc.mjs",
+		"lib/.jestrc.mjs",
+	);
+	expect(copyFile).toHaveBeenNthCalledWith(
+		10,
+		"lib/esm/jestTransformerBinaryFile.mjs",
+		"lib/jestTransformerBinaryFile.mjs",
+	);
+});

--- a/scripts/utils/__tests__/copyUncompiledFilesToLib.test.js
+++ b/scripts/utils/__tests__/copyUncompiledFilesToLib.test.js
@@ -1,0 +1,35 @@
+import {copyFile, readdir} from "node:fs/promises";
+import {uncompiledFiles} from "../__mocks__/files.js";
+import {copyUncompiledFilesToLib} from "../copyUncompiledFilesToLib";
+
+// const uncompiledFiles = [
+// 	".prettierignore",
+// 	"tsconfig.base.json",
+// 	"tsconfig.cjs.json",
+// 	"tsconfig.esm.json",
+// ];
+
+// Refer to scripts/utils/__tests__/copyCompiledFilesToLib.test.js for how/where `readdir` is mocked.
+readdir.mockImplementation(() => uncompiledFiles);
+
+test("it copies uncompiled non-TypeScript files from src/ to lib/", async () => {
+	await copyUncompiledFilesToLib();
+
+	// Verify that `readdir` was called once on the src/ directory.
+	expect(readdir).toHaveBeenCalledTimes(1);
+	expect(readdir).toHaveBeenCalledWith("src/");
+
+	// Verify that `copyFile` was called once for each item in `uncompiledFiles`.
+	expect(copyFile).toHaveBeenCalledTimes(4);
+	// Verify that a sampling of `copyFile` calls received the correct arguments.
+	expect(copyFile).toHaveBeenNthCalledWith(
+		1,
+		"src/.prettierignore",
+		"lib/.prettierignore",
+	);
+	expect(copyFile).toHaveBeenNthCalledWith(
+		4,
+		"src/tsconfig.esm.json",
+		"lib/tsconfig.esm.json",
+	);
+});

--- a/scripts/utils/__tests__/deleteDirectoriesInLib.test.js
+++ b/scripts/utils/__tests__/deleteDirectoriesInLib.test.js
@@ -1,0 +1,13 @@
+import {rm} from "node:fs/promises";
+import {deleteDirectoriesInLib} from "../deleteDirectoriesInLib.js";
+
+test("it removes the lib/cjs/ and lib/esm/ directories with the force and recursive options", async () => {
+	const rmOptions = {force: true, recursive: true};
+
+	await deleteDirectoriesInLib();
+
+	// Verify that `rm` was called twice on the correct directories and with the correct options.
+	expect(rm).toHaveBeenCalledTimes(2);
+	expect(rm).toHaveBeenNthCalledWith(1, "lib/cjs/", rmOptions);
+	expect(rm).toHaveBeenNthCalledWith(2, "lib/esm/", rmOptions);
+});

--- a/scripts/utils/__tests__/renameFilesInLibCJS.test.js
+++ b/scripts/utils/__tests__/renameFilesInLibCJS.test.js
@@ -1,0 +1,28 @@
+import {readdir, rename} from "node:fs/promises";
+import {compiledFiles} from "../__mocks__/files.js";
+import {renameFilesInLibCJS} from "../renameFilesInLibCJS";
+
+// Refer to scripts/utils/__tests__/copyCompiledFilesToLib.test.js for how/where `readdir` is mocked.
+readdir.mockImplementation(() => compiledFiles);
+
+test("it renames the files in lib/cjs/ by changing their extensions from .js to .cjs ", async () => {
+	await renameFilesInLibCJS();
+
+	// Verify that `readdir` was called once and on the lib/cjs/ directory.
+	expect(readdir).toHaveBeenCalledTimes(1);
+	expect(readdir).toHaveBeenCalledWith("lib/cjs/");
+
+	// Verify that `rename` was called once for each item in `compiledFiles`.
+	expect(rename).toHaveBeenCalledTimes(5);
+	// Verify that a sampling of `rename` calls received the correct arguments.
+	expect(rename).toHaveBeenNthCalledWith(
+		1,
+		"lib/cjs/.jestrc.js",
+		"lib/cjs/.jestrc.cjs",
+	);
+	expect(rename).toHaveBeenNthCalledWith(
+		5,
+		"lib/cjs/jestTransformerBinaryFile.js",
+		"lib/cjs/jestTransformerBinaryFile.cjs",
+	);
+});

--- a/scripts/utils/__tests__/renameFilesInLibESM.test.js
+++ b/scripts/utils/__tests__/renameFilesInLibESM.test.js
@@ -1,0 +1,36 @@
+import {readdir, rename} from "node:fs/promises";
+import {compiledFiles} from "../__mocks__/files.js";
+import {renameFilesInLibESM} from "../renameFilesInLibESM";
+
+// const esmFiles = [
+// 	".jestrc.js",
+// 	".prettierrc.js",
+// 	"jestMockNodeCoreModules.js",
+// 	"jestTransformerBabelJest.js",
+// 	"jestTransformerBinaryFile.js",
+// ];
+
+// Refer to scripts/utils/__tests__/copyCompiledFilesToLib.test.js for how/where `readdir` is mocked.
+readdir.mockImplementation(() => compiledFiles);
+
+test("it renames the files in lib/esm/ by changing their extensions from .js to .mjs ", async () => {
+	await renameFilesInLibESM();
+
+	// Verify that `readdir` was called once and on the lib/esm/ directory.
+	expect(readdir).toHaveBeenCalledTimes(1);
+	expect(readdir).toHaveBeenCalledWith("lib/esm/");
+
+	// Verify that `rename` was called once for each item in `compiledFiles`.
+	expect(rename).toHaveBeenCalledTimes(5);
+	// Verify that a sampling of `rename` calls received the correct arguments.
+	expect(rename).toHaveBeenNthCalledWith(
+		1,
+		"lib/esm/.jestrc.js",
+		"lib/esm/.jestrc.mjs",
+	);
+	expect(rename).toHaveBeenNthCalledWith(
+		5,
+		"lib/esm/jestTransformerBinaryFile.js",
+		"lib/esm/jestTransformerBinaryFile.mjs",
+	);
+});

--- a/scripts/utils/appendPrettierConfigFile.js
+++ b/scripts/utils/appendPrettierConfigFile.js
@@ -1,0 +1,15 @@
+import {appendFile} from "node:fs/promises";
+
+/**
+ * Note that Prettier requires a CommonJS file using `module.exports` in its current v2 iteration, but if this changes
+ * in v3 then it may be possible to remove all CommonJS-related code/compilation from this repository entirely.
+ *
+ * Excerpt from https://prettier.io/docs/en/configuration.html:
+ * > You can configure Prettier via a `.prettierrc.cjs` file that exports an object using `module.exports`.
+ */
+export const appendPrettierConfigFile = async () => {
+	await appendFile(
+		"lib/cjs/.prettierrc.cjs",
+		"module.exports = exports.prettierConfig;\n",
+	);
+};

--- a/scripts/utils/copyCompiledFilesToLib.js
+++ b/scripts/utils/copyCompiledFilesToLib.js
@@ -1,0 +1,18 @@
+import {copyFile, readdir} from "node:fs/promises";
+
+// Originally I wanted to use async/await with the `forEach()` function, but this doesn't always
+// work the way that I expect it to. MDN suggests using `for of` as a succinct alternative.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises#composition
+
+/** Copy the compiled TypeScript files from lib/cjs/ and lib/esm/ to lib/ */
+export const copyCompiledFilesToLib = async () => {
+	const cjsFiles = await readdir("lib/cjs/");
+	for (const file of cjsFiles) {
+		await copyFile(`lib/cjs/${file}`, `lib/${file}`);
+	}
+
+	const esmFiles = await readdir("lib/esm/");
+	for (const file of esmFiles) {
+		await copyFile(`lib/esm/${file}`, `lib/${file}`);
+	}
+};

--- a/scripts/utils/copyUncompiledFilesToLib.js
+++ b/scripts/utils/copyUncompiledFilesToLib.js
@@ -1,0 +1,18 @@
+import {copyFile, readdir} from "node:fs/promises";
+
+/** Copy the uncompiled non-TypeScript files from src/ to lib/ */
+export const copyUncompiledFilesToLib = async () => {
+	const srcFiles = await readdir("src/");
+
+	const dotFiles = srcFiles.filter((file) => {
+		if (file[0] === "." && !file.includes(".ts")) {
+			return file;
+		}
+	});
+	const jsonFiles = srcFiles.filter((file) => file.includes(".json"));
+
+	const filesToCopy = [...dotFiles, ...jsonFiles];
+	for (const file of filesToCopy) {
+		await copyFile(`src/${file}`, `lib/${file}`);
+	}
+};

--- a/scripts/utils/deleteDirectoriesInLib.js
+++ b/scripts/utils/deleteDirectoriesInLib.js
@@ -1,0 +1,7 @@
+import {rm} from "node:fs/promises";
+
+/** Delete the lib/cjs/ and lib/esm/ directories. */
+export const deleteDirectoriesInLib = async () => {
+	await rm("lib/cjs/", {force: true, recursive: true});
+	await rm("lib/esm/", {force: true, recursive: true});
+};

--- a/scripts/utils/renameFilesInLibCJS.js
+++ b/scripts/utils/renameFilesInLibCJS.js
@@ -1,0 +1,10 @@
+import {readdir, rename} from "node:fs/promises";
+
+/** Rename files in lib/cjs/ by changing their extensions from .js to .cjs */
+export const renameFilesInLibCJS = async () => {
+	const cjsFiles = await readdir("lib/cjs/");
+	const cjsFileNames = cjsFiles.map((file) => file.replace(".js", ""));
+	for (const fileName of cjsFileNames) {
+		await rename(`lib/cjs/${fileName}.js`, `lib/cjs/${fileName}.cjs`);
+	}
+};

--- a/scripts/utils/renameFilesInLibESM.js
+++ b/scripts/utils/renameFilesInLibESM.js
@@ -1,0 +1,10 @@
+import {readdir, rename} from "node:fs/promises";
+
+/** Rename files in lib/esm/ by changing their extensions from .js to .mjs */
+export const renameFilesInLibESM = async () => {
+	const esmFiles = await readdir("lib/esm/");
+	const esmFileNames = esmFiles.map((file) => file.replace(".js", ""));
+	for (const fileName of esmFileNames) {
+		await rename(`lib/esm/${fileName}.js`, `lib/esm/${fileName}.mjs`);
+	}
+};

--- a/src/.jestrc.ts
+++ b/src/.jestrc.ts
@@ -8,6 +8,11 @@ const binaryFileExtensions = {
 	},
 };
 
+/** Paths to setup files. */
+const setupFiles = {
+	mockNodeCoreModules: "jestMockNodeCoreModules.mjs",
+};
+
 /** Paths to the files/node_modules used as transformers. */
 const transformers = {
 	babelJest: "jestTransformerBabelJest.mjs",
@@ -57,6 +62,14 @@ const jestConfig: Config = {
 	// > By default, `roots` has a single entry `<rootDir>` but there are cases where you may want to have multiple roots within one project,
 	// > for example roots: `["<rootDir>/src/", "<rootDir>/tests/"]`.
 	roots: ["../scripts/", "../src/"],
+	// Mock out the Node.js core modules during setup to avoid having to repeatedly mock them in every test file
+	// where the module being tested relies on methods that are imported from Node.js core modules.
+	// Excerpt from https://jestjs.io/docs/configuration#setupfilesafterenv-array:
+	// > A list of paths to modules that run some code to configure or set up the testing framework before each test file in the suite
+	// > is executed. Since `setupFiles` executes before the test framework is installed in the environment, this script file presents you
+	// > the opportunity of running some code immediately after the test framework has been installed in the environment but before
+	// > the test code itself. In other words, `setupFilesAfterEnv` modules are meant for code which is repeating in each test file.
+	setupFilesAfterEnv: [`../lib/${setupFiles.mockNodeCoreModules}`],
 	// Explicitly declare either `"node"|"jsdom"` as the testing environment for each extending repository that uses this Jest config.
 	// Excerpt from https://jestjs.io/docs/configuration#testenvironment-string:
 	// > The test environment that will be used for testing. The default environment in Jest is a Node.js environment.
@@ -98,10 +111,11 @@ const jestConfig: Config = {
  * ```
  */
 export const jestConfigOverrides: Config = {
+	setupFilesAfterEnv: [`dr-devdeps/lib/${setupFiles.mockNodeCoreModules}`],
 	transform: {
 		[transformFileExtensions.binary]:
-			// Reference `dr-devdeps` in this way because it's installed in the node_modules/ directory
-			// as a dependency of the extending repository.
+			// Reference `dr-devdeps` in this way because it's installed in the
+			// node_modules/ directory as a dependency of the extending repository.
 			`dr-devdeps/lib/${transformers.binaryFile}`,
 		[transformFileExtensions.javascript]: `dr-devdeps/lib/${transformers.babelJest}`,
 		[transformFileExtensions.typescript]: [

--- a/src/jestMockNodeCoreModules.ts
+++ b/src/jestMockNodeCoreModules.ts
@@ -1,0 +1,8 @@
+// Excerpt from https://jestjs.io/docs/configuration#automock-boolean:
+// > Node.js core modules, like `fs`, are not mocked by default. They can be mocked explicitly, like `jest.mock("fs")`.
+
+// Excerpt from https://jestjs.io/docs/manual-mocks#mocking-node-modules:
+// > CAUTION: If we want to mock Node's built-in modules (e.g.: `fs` or `path`), then explicitly calling
+// > e.g. `jest.mock("path")` is required, because built-in modules are not mocked by default.
+
+jest.mock("node:fs/promises");

--- a/src/tsconfig.base.json
+++ b/src/tsconfig.base.json
@@ -2,6 +2,7 @@
 	"files": [
 		".jestrc.ts",
 		".prettierrc.ts",
+		"jestMockNodeCoreModules.ts",
 		"jestTransformerBabelJest.ts",
 		"jestTransformerBinaryFile.ts"
 	],


### PR DESCRIPTION
Summary of changes:

- Write `jestMockNodeCoreModules` and add it to `setupFilesAfterEnv` to mock out the Node.js core modules during test setup to avoid having to repeatedly mock them in every test file.
- Move the various functions out of scripts/postbuild.js and into their own separate modules in scripts/utils/.
- Write unit tests for scripts/postbuild.js and every module in scripts/utils/.