### PR TITLE
Update Jest config to run tests in ESM mode

### DIFF
--- a/src/__tests__/jest.config.devdeps.test.ts
+++ b/src/__tests__/jest.config.devdeps.test.ts
@@ -20,6 +20,7 @@ test("that the `transform` configuration is correct", () => {
 			"ts-jest",
 			{
 				tsconfig: "<rootDir>/tsconfig.test.json",
+				useESM: true,
 			},
 		],
 	});

--- a/src/__tests__/jest.config.test.ts
+++ b/src/__tests__/jest.config.test.ts
@@ -23,6 +23,7 @@ test("the `transform` configuration is correct", () => {
 			"ts-jest",
 			{
 				tsconfig: "<rootDir>/node_modules/dr-devdeps/tsconfig.test.json",
+				useESM: true,
 			},
 		],
 	});

--- a/src/jest.config.ts
+++ b/src/jest.config.ts
@@ -49,6 +49,7 @@ export const getTransformConfig = (overrides?: {
 			{
 				// Set the `tsconfig` config option due to the need for a test-specific TypeScript configuration file.
 				tsconfig: `${basePath}/tsconfig.test.json`,
+				useESM: true,
 			},
 		],
 	} as const;
@@ -81,6 +82,10 @@ const jestConfig: Config = {
 			statements: 100,
 		},
 	},
+	// Excerpt from https://jestjs.io/docs/configuration#extensionstotreatasesm-arraystring:
+	// > Jest will run `.mjs` and `.js` files with nearest `package.json`'s `type` field set to `module` as ECMAScript Modules.
+	// > If you have any other files that should run with native ESM, you need to specify their file extension here.
+	extensionsToTreatAsEsm: [".jsx", ".ts", ".tsx"],
 	// Excerpt from https://jestjs.io/docs/configuration#modulefileextensions-arraystring:
 	// > We recommend placing the extensions most commonly used in your project on the left, so if you are
 	// > using TypeScript, you may want to consider moving "ts" and/or "tsx" to the beginning of the array.


### PR DESCRIPTION
Summary of changes:

- Set `useESM: true` in the ts-jest configuration object.
- Tell Jest to treat `.js`, `.ts` and `.tsx` files as ESM.

Supporting resources:

- https://jestjs.io/docs/ecmascript-modules
- https://kulshekhar.github.io/ts-jest/docs/guides/esm-support