### PR TITLE
Add functions to get repo metadata and to check dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "dr-devdeps",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dr-devdeps",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"description": "",
 	"main": "index.js",
 	"scripts": {

--- a/src/utils/__tests__/dependsOn.test.ts
+++ b/src/utils/__tests__/dependsOn.test.ts
@@ -1,0 +1,104 @@
+import {readFile} from "node:fs/promises";
+import {type Mock, vi} from "vitest";
+import {dependsOn} from "../dependsOn.js";
+import {getRepoMetadata} from "../getRepoMetadata.js";
+
+vi.mock("node:fs/promises", () => ({
+	readFile: vi.fn(),
+}));
+// Paraphrased excerpt from https://www.mikeborozdin.com/post/changing-jest-mocks-between-tests:
+// > Typecast the imported mocked module into an object with writeable properties.
+const mockReadFile = readFile as Mock;
+
+vi.mock("../getRepoMetadata.js", () => ({
+	getRepoMetadata: vi.fn(() => ({
+		absoluteRootDir: "/Users/username/repos/dr-devdeps",
+		isDevDepsRepo: true,
+	})),
+}));
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+test("throws errors if the `deps` argument is invalid", () => {
+	expect(async () => {
+		// @ts-expect-error if no `deps` argument is passed.
+		await dependsOn();
+	}).rejects.toThrow();
+
+	expect(async () => {
+		// @ts-expect-error if `deps` argument is not an array.
+		await dependsOn("package1");
+	}).rejects.toThrow();
+
+	expect(async () => {
+		// Expect an error if `deps` argument is an empty array.
+		await dependsOn([]);
+	}).rejects.toThrow();
+
+	expect(async () => {
+		// @ts-expect-error if `deps` argument is an array containing non-string values.
+		await dependsOn(["package1", 2, "package3"]);
+	}).rejects.toThrow();
+});
+
+test("returns `false` if the repo does not depend on the package", async () => {
+	const packageJsonContents = `
+{
+	"dependencies": {
+		"dep1": "major.minor.patch"
+	}
+}
+`;
+	mockReadFile.mockResolvedValue(packageJsonContents);
+
+	const dependsOnDep0 = await dependsOn(["dep0"]);
+
+	expect(getRepoMetadata).toHaveBeenCalledTimes(1);
+	expect(mockReadFile).toHaveBeenCalledWith(
+		"/Users/username/repos/dr-devdeps/package.json",
+		{encoding: "utf-8"},
+	);
+	expect(dependsOnDep0).toBe(false);
+});
+
+test("returns `true` if the repo does depend on the package", async () => {
+	const packageJsonContents = `
+{
+	"devDependencies": {
+		"devDep1": "major.minor.patch"
+	}
+}
+`;
+	mockReadFile.mockResolvedValue(packageJsonContents);
+
+	const dependsOnDevDep1 = await dependsOn(["devDep1"]);
+
+	expect(getRepoMetadata).toHaveBeenCalledTimes(1);
+	expect(mockReadFile).toHaveBeenCalledTimes(1);
+	expect(dependsOnDevDep1).toBe(true);
+});
+
+test("returns `true` if the repo depends on at least one of the passed packages", async () => {
+	const packageJsonContents = `
+{
+	"dependencies": {
+		"dep1": "major.minor.patch"
+	},
+	"devDependencies": {
+		"devDep1": "major.minor.patch"
+	},
+	"peerDependencies": {
+		"peerDep1": "major.minor.patch"
+	}
+}
+`;
+	mockReadFile.mockResolvedValue(packageJsonContents);
+
+	const dependsOnPeerDep1 = await dependsOn(["dep0", "devDep0", "peerDep1"]);
+
+	expect(getRepoMetadata).toHaveBeenCalledTimes(1);
+	expect(mockReadFile).toHaveBeenCalledTimes(1);
+	expect(dependsOnPeerDep1).toBe(true);
+});

--- a/src/utils/__tests__/getRepoMetadata.test.ts
+++ b/src/utils/__tests__/getRepoMetadata.test.ts
@@ -1,0 +1,65 @@
+import {fileURLToPath} from "node:url";
+import {type Mock, vi} from "vitest";
+import {getRepoMetadata} from "../getRepoMetadata.js";
+
+vi.mock("node:url", () => ({
+	fileURLToPath: vi.fn(),
+}));
+// Paraphrased excerpt from https://www.mikeborozdin.com/post/changing-jest-mocks-between-tests:
+// > Typecast the imported mocked module into an object with writeable properties.
+const mockFileURLToPath = fileURLToPath as Mock;
+
+test("throws an error if partialPath is not present within absolutePath", () => {
+	const absolutePath = "/Users/username/repos/bad-path";
+	mockFileURLToPath.mockReturnValue(absolutePath);
+
+	expect(() => {
+		getRepoMetadata();
+	}).toThrow();
+});
+
+describe("it determines the correct absolute root directory", () => {
+	test("when installed as a dependency being run inside a node_modules folder", () => {
+		const absolutePath =
+			"/Users/username/repos/consuming-repo/node_modules/dr-devdeps/lib/utils/getRepoMetadata.js";
+		mockFileURLToPath.mockReturnValue(absolutePath);
+
+		const {absoluteRootDir, isDevDepsRepo} = getRepoMetadata();
+
+		expect(absoluteRootDir).toStrictEqual(
+			"/Users/username/repos/consuming-repo",
+		);
+		expect(absoluteRootDir).not.toContain("node_modules/dr-devdeps");
+		expect(absoluteRootDir).not.toContain("lib");
+		expect(absoluteRootDir).not.toContain("utils/getRepoMetadata.js");
+		expect(isDevDepsRepo).toBe(false);
+	});
+
+	// Simulate this dr-devdeps repo accessing the compiled .js file.
+	test("when run as a JavaScript file inside the lib/ folder", () => {
+		const absolutePath =
+			"/Users/username/repos/dr-devdeps/lib/utils/getRepoMetadata.js";
+		mockFileURLToPath.mockReturnValue(absolutePath);
+
+		const {absoluteRootDir, isDevDepsRepo} = getRepoMetadata();
+
+		expect(absoluteRootDir).toStrictEqual("/Users/username/repos/dr-devdeps");
+		expect(absoluteRootDir).not.toContain("lib");
+		expect(absoluteRootDir).not.toContain("utils/getRepoMetadata.js");
+		expect(isDevDepsRepo).toBe(true);
+	});
+
+	// Simulate this dr-devdeps repo accessing the source .ts file during a test run.
+	test("when run as a TypeScript file inside the src/ folder", () => {
+		const absolutePath =
+			"/Users/username/repos/dr-devdeps/src/utils/getRepoMetadata.ts";
+		mockFileURLToPath.mockReturnValue(absolutePath);
+
+		const {absoluteRootDir, isDevDepsRepo} = getRepoMetadata();
+
+		expect(absoluteRootDir).toStrictEqual("/Users/username/repos/dr-devdeps");
+		expect(absoluteRootDir).not.toContain("src");
+		expect(absoluteRootDir).not.toContain("utils/getRepoMetadata.ts");
+		expect(isDevDepsRepo).toBe(true);
+	});
+});

--- a/src/utils/dependsOn.ts
+++ b/src/utils/dependsOn.ts
@@ -1,0 +1,56 @@
+import {readFile} from "node:fs/promises";
+import {getRepoMetadata} from "./getRepoMetadata.js";
+
+/**
+ * Given a list of dependencies, check the repository's package.json file
+ * and determine whether or not the project depends on any of them.
+ */
+export const dependsOn = async (deps: string[]) => {
+	// It's possible to use this function directly from the compiled lib/ .js file,
+	// so start with some manual typechecking and throw errors early if needed.
+	if (!Array.isArray(deps) || deps.length === 0) {
+		throw new Error(
+			"Argument for the `deps` parameter must be an array of strings with a length >= 1. Received:" +
+				"\n" +
+				`- typeof deps = ${typeof deps}` +
+				"\n" +
+				`- deps = ${deps}`,
+		);
+	}
+	deps.forEach((dep) => {
+		if (typeof dep !== "string") {
+			throw new Error(
+				"All values in the `deps` array must be strings. Received:" +
+					"\n" +
+					`- typeof dep = ${typeof dep}` +
+					"\n" +
+					`- deps = ${deps}` +
+					"\n" +
+					`- dep = ${dep}`,
+			);
+		}
+	});
+
+	// Read the package.json file and parse its string contents into an object,
+	// then merge its three dependency objects into one combined object.
+	const packageJsonPath = `${getRepoMetadata().absoluteRootDir}/package.json`;
+	const packageJsonContents = await readFile(packageJsonPath, {
+		encoding: "utf-8",
+	});
+	const packageJson = JSON.parse(packageJsonContents);
+	const allDependencies = {
+		...packageJson.dependencies,
+		...packageJson.devDependencies,
+		...packageJson.peerDependencies,
+	};
+
+	// Determine whether or not the package.json file has any of the passed dependencies.
+	let hasDependency = false;
+	deps.forEach((dep) => {
+		if (allDependencies[dep]) {
+			hasDependency = true;
+		}
+	});
+
+	return hasDependency;
+};

--- a/src/utils/getRepoMetadata.ts
+++ b/src/utils/getRepoMetadata.ts
@@ -1,0 +1,57 @@
+import {fileURLToPath} from "node:url";
+
+/**
+ * The purpose of this function is to provide a more robust alternative to `process.cwd()`. As per
+ * the Node.js documentation on https://nodejs.org/docs/latest-v20.x/api/process.html#processcwd:
+ * > The `process.cwd()` method returns the current working directory of the Node.js process.
+ *
+ * The problem with relying on this method is that it's dependent on the directory where the Node.js process was started from;
+ * if it's run from anywhere but the root of the repository then it will not return the desired path.
+ *
+ * This function uses the known location of this file within the repo's structure and uses it to figure out the
+ * absolute root directory of the repo where it's being called from. It can return the absolute path of either:
+ * 1. The consuming repository where the `dr-devdeps` package is installed as a dependency; or
+ * 2. This `dr-devdeps` repo itself.
+ *
+ * **Important:** Note that the `absoluteRootDir` path is intentionally returned without a trailing slash.
+ */
+export const getRepoMetadata = () => {
+	const absolutePath = fileURLToPath(import.meta.url);
+	/**
+	 * `partialPath` is known and stable; this partial is agnostic of differences between
+	 * folder locations (`lib` or `src`) and file extensions (`.js` or `.ts`).
+	 */
+	const partialPath = "utils/getRepoMetadata";
+
+	// This function depends on its path being known (i.e. the folder being `/utils/` and the
+	// filename being `getRepoMetadata`), so throw an early error if anything is misaligned.
+	if (!absolutePath.includes(partialPath)) {
+		throw new Error(
+			`partialPath string (value = ${partialPath}) is not present within absolutePath string (value = ${absolutePath}).`,
+		);
+	}
+	/** `dependencyPartialPath` is known and stable; this partial is known when the `dr-devdeps` package is installed as a dependency. */
+	const dependencyPartialPath = "node_modules/dr-devdeps";
+	/**
+	 * `relativePath` is defined as a regular expression so that it covers two types of paths:
+	 * 1. A compiled JavaScript file in the lib/ directory; and
+	 * 2. A TypeScript file in the src/ directory.
+	 */
+	const relativePath = new RegExp(`(lib|src)/${partialPath}.(js|ts)`);
+	/** `dependencyRelativePath` is defined as a regular expression built from the previous variables. */
+	const dependencyRelativePath = new RegExp(
+		`${dependencyPartialPath}/${relativePath.source}`,
+	);
+	let absoluteRootDir;
+	if (absolutePath.includes(dependencyPartialPath)) {
+		absoluteRootDir = absolutePath.replace(dependencyRelativePath, "");
+	} else {
+		absoluteRootDir = absolutePath.replace(relativePath, "");
+	}
+	// Slice off the last character in the string, i.e. the path's trailing slash.
+	absoluteRootDir = absoluteRootDir.slice(0, -1);
+
+	const isDevDepsRepo = absoluteRootDir.endsWith("/dr-devdeps");
+
+	return {absoluteRootDir, isDevDepsRepo} as const;
+};

--- a/src/utils/getRepoMetadata.ts
+++ b/src/utils/getRepoMetadata.ts
@@ -8,12 +8,12 @@ import {fileURLToPath} from "node:url";
  * The problem with relying on this method is that it's dependent on the directory where the Node.js process was started from;
  * if it's run from anywhere but the root of the repository then it will not return the desired path.
  *
- * This function uses the known location of this file within the repo's structure and uses it to figure out the
- * absolute root directory of the repo where it's being called from. It can return the absolute path of either:
+ * This function uses the known location of the `utils/getRepoMetadata` file within the repo's structure and uses it as an anchor point
+ * to determine the absolute root directory of the repo where it's being called from. It can return the absolute path of either:
  * 1. The consuming repository where the `dr-devdeps` package is installed as a dependency; or
  * 2. This `dr-devdeps` repo itself.
  *
- * **Important:** Note that the `absoluteRootDir` path is intentionally returned without a trailing slash.
+ * **Important:** Note that the `absoluteRootDir` path is intentionally returned _without_ a trailing slash.
  */
 export const getRepoMetadata = () => {
 	const absolutePath = fileURLToPath(import.meta.url);


### PR DESCRIPTION
- The `dependsOn` function is given a list of dependencies and checks the repository's package.json file to determine whether or not the project depends on any of them.
- The `getRepoMetadata` function serves as a more robust alternative to the `process.cwd()` Node.js method.
  - The problem with relying on `process.cwd()` is that it's dependent on the directory where the Node.js process was started from; if it's run from anywhere but the root of the repository then it will not return the desired path.
  - By contrast, this `getRepoMetadata` function uses the known location of the `utils/getRepoMetadata` file within the repo's structure and uses it as an anchor point to determine the absolute root directory of the repo where it's being called from. It can return the absolute path of either:
    1. The consuming repository where the `dr-devdeps` package is installed as a dependency; or
    2. This `dr-devdeps` repo itself.
- Manually bump the package.json version number to 0.13.0.