### PR TITLE
Configure XML Prettier plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Related file: .vscode/settings.json
+
 # Use this .gitignore file as the `--ignore-path` for ESLint and Prettier as well,
 # since everything that's excluded from repo source control shouldn't be checked.
 coverage/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
 	// Specify that the Git hook files are shell scripts because VS Code misidentifies some of them as Markdown due to code comments.
 	"files.associations": {
-		// ~/.githooks/
+		// .githooks/
 		"commit-msg": "shellscript",
 		"pre-commit": "shellscript",
 		"pre-push": "shellscript"
@@ -14,5 +14,13 @@
 	"material-icon-theme.files.associations": {
 		"src/eslint.config.ts": "eslint",
 		"src/prettier.config.ts": "prettier"
-	}
+	},
+	// The simplest and most straightforward way to ensure that the IDE extensions for ESLint and Prettier work correctly in the editor
+	// is to specify the paths (relative to the root of the repo) to configuration and ignore files here in this VS Code settings file.
+	//
+	// GitHub issues related to Prettier plugins failing to autoformat files on save:
+	// https://github.com/prettier/prettier-vscode/issues/3104
+	// https://github.com/prettier/prettier-vscode/issues/3235
+	"prettier.configPath": "./lib/prettier.config.js",
+	"prettier.ignorePath": "./.gitignore"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dr-devdeps",
-	"version": "0.13.0",
+	"version": "0.14.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dr-devdeps",
-			"version": "0.13.0",
+			"version": "0.14.0",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 			"dependencies": {
 				"@commitlint/cli": "18.6.1",
 				"@commitlint/config-conventional": "18.6.2",
+				"@prettier/plugin-xml": "3.3.1",
 				"@swc/core": "1.4.2",
 				"@swc/jest": "0.2.36",
 				"@tsconfig/strictest": "2.0.3",
@@ -1839,6 +1840,17 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@prettier/plugin-xml": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.3.1.tgz",
+			"integrity": "sha512-kllNJk6n2pXJjGWdj+HAr1GhOoOTrlmeWkDYCGBzkyZS2l0K6h2gsUQcVif2cNqAE1MNC+nUrzN6QwEsCukPnQ==",
+			"dependencies": {
+				"@xml-tools/parser": "^1.0.11"
+			},
+			"peerDependencies": {
+				"prettier": "^3.0.0"
+			}
+		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.12.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.0.tgz",
@@ -2808,6 +2820,14 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/@xml-tools/parser": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
+			"integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
+			"dependencies": {
+				"chevrotain": "7.1.1"
+			}
+		},
 		"node_modules/abab": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -3229,6 +3249,14 @@
 			},
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/chevrotain": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
+			"integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
+			"dependencies": {
+				"regexp-to-ast": "0.5.0"
 			}
 		},
 		"node_modules/ci-info": {
@@ -6936,6 +6964,11 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/regexp-to-ast": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+			"integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="
+		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -9412,6 +9445,14 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@prettier/plugin-xml": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.3.1.tgz",
+			"integrity": "sha512-kllNJk6n2pXJjGWdj+HAr1GhOoOTrlmeWkDYCGBzkyZS2l0K6h2gsUQcVif2cNqAE1MNC+nUrzN6QwEsCukPnQ==",
+			"requires": {
+				"@xml-tools/parser": "^1.0.11"
+			}
+		},
 		"@rollup/rollup-android-arm-eabi": {
 			"version": "4.12.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.0.tgz",
@@ -10039,6 +10080,14 @@
 				"pretty-format": "^29.7.0"
 			}
 		},
+		"@xml-tools/parser": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
+			"integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
+			"requires": {
+				"chevrotain": "7.1.1"
+			}
+		},
 		"abab": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -10326,6 +10375,14 @@
 			"integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
 			"requires": {
 				"get-func-name": "^2.0.2"
+			}
+		},
+		"chevrotain": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
+			"integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
+			"requires": {
+				"regexp-to-ast": "0.5.0"
 			}
 		},
 		"ci-info": {
@@ -12933,6 +12990,11 @@
 				"indent-string": "^4.0.0",
 				"strip-indent": "^3.0.0"
 			}
+		},
+		"regexp-to-ast": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+			"integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="
 		},
 		"require-directory": {
 			"version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dr-devdeps",
-	"version": "0.13.0",
+	"version": "0.14.0",
 	"description": "",
 	"main": "index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"build": "npm run build:cjs & npm run build:esm",
 		"postbuild": "node ./scripts/postbuild.js",
 		"// format": "Scripts for auto-formatting the codebase.",
-		"format": "prettier --ignore-path ./.gitignore",
+		"format": "prettier --config ./lib/prettier.config.js --ignore-path ./.gitignore",
 		"format:check": "npm run format -- --check ./",
 		"format:write": "npm run format -- --write ./",
 		"// githooks": "Refer to the files in the ./.githooks/ folder for documentation on these commands.",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 	"dependencies": {
 		"@commitlint/cli": "18.6.1",
 		"@commitlint/config-conventional": "18.6.2",
+		"@prettier/plugin-xml": "3.3.1",
 		"@swc/core": "1.4.2",
 		"@swc/jest": "0.2.36",
 		"@tsconfig/strictest": "2.0.3",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,1 +1,0 @@
-export {default} from "./lib/prettier.config.js";

--- a/src/__tests__/prettier.config.test.ts
+++ b/src/__tests__/prettier.config.test.ts
@@ -12,3 +12,13 @@ test("the most important configuration options are correct", () => {
 	expect(prettierConfig.trailingComma).toEqual("all");
 	expect(prettierConfig.useTabs).toBe(true);
 });
+
+test("the XML plugin and configuration are present", () => {
+	expect(prettierConfig.plugins).toStrictEqual(["@prettier/plugin-xml"]);
+	/* eslint-disable dot-notation */
+	expect(prettierConfig["xmlQuoteAttributes"]).toEqual("double");
+	expect(prettierConfig["xmlSelfClosingSpace"]).toBe(true);
+	expect(prettierConfig["xmlSortAttributesByKey"]).toBe(true);
+	expect(prettierConfig["xmlWhitespaceSensitivity"]).toEqual("ignore");
+	/* eslint-enable dot-notation */
+});

--- a/src/prettier-plugins/__tests__/xml.test.ts
+++ b/src/prettier-plugins/__tests__/xml.test.ts
@@ -1,4 +1,4 @@
-import { xmlPrettierPlugin } from "../xml.js";
+import {xmlPrettierPlugin} from "../xml.js";
 
 test("it has the correct types", () => {
 	expect(typeof xmlPrettierPlugin).toEqual("object");

--- a/src/prettier-plugins/__tests__/xml.test.ts
+++ b/src/prettier-plugins/__tests__/xml.test.ts
@@ -1,0 +1,15 @@
+import { xmlPrettierPlugin } from "../xml.js";
+
+test("it has the correct types", () => {
+	expect(typeof xmlPrettierPlugin).toEqual("object");
+	expect(typeof xmlPrettierPlugin.config).toEqual("object");
+	expect(typeof xmlPrettierPlugin.name).toEqual("string");
+});
+
+test("the most important configuration options and the plugin name are correct", () => {
+	expect(xmlPrettierPlugin.config.xmlQuoteAttributes).toEqual("double");
+	expect(xmlPrettierPlugin.config.xmlSelfClosingSpace).toBe(true);
+	expect(xmlPrettierPlugin.config.xmlSortAttributesByKey).toBe(true);
+	expect(xmlPrettierPlugin.config.xmlWhitespaceSensitivity).toEqual("ignore");
+	expect(xmlPrettierPlugin.name).toEqual("@prettier/plugin-xml");
+});

--- a/src/prettier-plugins/xml.ts
+++ b/src/prettier-plugins/xml.ts
@@ -1,0 +1,24 @@
+/** https://github.com/prettier/plugin-xml */
+export const xmlPrettierPlugin = {
+	config: {
+		// Excerpts from https://github.com/prettier/plugin-xml#configuration:
+		xmlQuoteAttributes: "double",
+		// > Adds a space before self-closing tags.
+		xmlSelfClosingSpace: true,
+		// > Orders XML attributes by key alphabetically while prioritizing `xmlns` attributes.
+		xmlSortAttributesByKey: true,
+		// Excerpts from https://github.com/prettier/plugin-xml#whitespace:
+		// > In XML, by default, all whitespace inside elements has semantic meaning. For Prettier to maintain its contract of not changing
+		// > the semantic meaning of your program, this means the default for `xmlWhitespaceSensitivity` is `"strict"`. When running in
+		// > this mode, Prettier's ability to rearrange your markup is somewhat limited, as it has to maintain the exact amount of whitespace
+		// > that you input within elements.
+		// >
+		// > If you're sure that the XML files that you're formatting do not require whitespace sensitivity, you can use the `"ignore"` option,
+		// > as this will produce a standardized amount of whitespace. This will fix any indentation issues, and collapse excess blank lines
+		// > (max of 1 blank line). For most folks most of the time, this is probably the option that you want.
+		// >
+		// > You can also use the `"preserve"` option, if you want to preserve the whitespace of text nodes within XML elements and attributes.
+		xmlWhitespaceSensitivity: "ignore",
+	},
+	name: "@prettier/plugin-xml",
+} as const;

--- a/src/prettier.config.ts
+++ b/src/prettier.config.ts
@@ -1,5 +1,5 @@
-import { type Config } from "prettier";
-import { xmlPrettierPlugin } from "./prettier-plugins/xml.js";
+import {type Config} from "prettier";
+import {xmlPrettierPlugin} from "./prettier-plugins/xml.js";
 
 /** https://prettier.io/docs/en/options.html */
 const prettierConfig: Config = {

--- a/src/prettier.config.ts
+++ b/src/prettier.config.ts
@@ -1,4 +1,5 @@
-import {type Config} from "prettier";
+import { type Config } from "prettier";
+import { xmlPrettierPlugin } from "./prettier-plugins/xml.js";
 
 /** https://prettier.io/docs/en/options.html */
 const prettierConfig: Config = {
@@ -49,6 +50,12 @@ const prettierConfig: Config = {
 	trailingComma: "all",
 	// Refer to .editorconfig file for the rationale of choosing to indent lines with tabs instead of spaces.
 	useTabs: true,
-} as const;
+	// Prettier plugins.
+	plugins: [
+		// SVG files use XML syntax, so use the XML plugin to check/autoformat them.
+		xmlPrettierPlugin.name,
+	],
+	...xmlPrettierPlugin.config,
+};
 
 export default prettierConfig;


### PR DESCRIPTION
SVG files use XML syntax, so use the XML plugin to check/autoformat them.

Summary of changes:

- Install `@prettier/plugin-xml` as a dependency and configure it.
- Switch Prettier configuration method from root `prettier.config.js` file to `.vscode/settings.json`.
- Manually bump the package.json version number to `0.14.0`.