### PR TITLE
Configure Pug Prettier plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dr-devdeps",
-	"version": "0.14.0",
+	"version": "0.15.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dr-devdeps",
-			"version": "0.14.0",
+			"version": "0.15.0",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 			"dependencies": {
 				"@commitlint/cli": "18.6.1",
 				"@commitlint/config-conventional": "18.6.2",
+				"@prettier/plugin-pug": "3.0.0",
 				"@prettier/plugin-xml": "3.3.1",
 				"@swc/core": "1.4.2",
 				"@swc/jest": "0.2.36",
@@ -1840,6 +1841,31 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@prettier/plugin-pug": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@prettier/plugin-pug/-/plugin-pug-3.0.0.tgz",
+			"integrity": "sha512-ERMMvGSJK/7CTc8OT7W/dtlV43sytyNeiCWckN0DIFepqwXotU0+coKMv5Wx6IWSNj7ZSjdNGBAA1nMPi388xw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/Shinigami92"
+				},
+				{
+					"type": "paypal",
+					"url": "https://www.paypal.com/donate/?hosted_button_id=L7GY729FBKTZY"
+				}
+			],
+			"dependencies": {
+				"pug-lexer": "^5.0.1"
+			},
+			"engines": {
+				"node": "^16.13.0 || >=18.0.0",
+				"npm": ">=7.10.0"
+			},
+			"peerDependencies": {
+				"prettier": "^3.0.0"
+			}
+		},
 		"node_modules/@prettier/plugin-xml": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.3.1.tgz",
@@ -3149,6 +3175,24 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/call-bind": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3238,6 +3282,14 @@
 			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/character-parser": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
+			"integrity": "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==",
+			"dependencies": {
+				"is-regex": "^1.0.3"
 			}
 		},
 		"node_modules/check-error": {
@@ -3699,6 +3751,22 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3806,6 +3874,25 @@
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"dependencies": {
 				"is-arrayish": "^0.2.1"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+			"dependencies": {
+				"get-intrinsic": "^1.2.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/esbuild": {
@@ -4321,9 +4408,12 @@
 			}
 		},
 		"node_modules/function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
@@ -4358,6 +4448,24 @@
 			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/get-package-type": {
@@ -4516,6 +4624,17 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/gopd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"dependencies": {
+				"get-intrinsic": "^1.1.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4551,6 +4670,64 @@
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-proto": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
+			"integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/hosted-git-info": {
@@ -4755,6 +4932,26 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-expression": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
+			"integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
+			"dependencies": {
+				"acorn": "^7.1.1",
+				"object-assign": "^4.1.1"
+			}
+		},
+		"node_modules/is-expression/node_modules/acorn": {
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4826,6 +5023,21 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
 			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+		},
+		"node_modules/is-regex": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",
@@ -6489,6 +6701,14 @@
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
 			"integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ=="
 		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6808,6 +7028,21 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
 			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+		},
+		"node_modules/pug-error": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz",
+			"integrity": "sha512-sjiUsi9M4RAGHktC1drQfCr5C5eriu24Lfbt4s+7SykztEOwVZtbFk1RRq0tzLxcMxMYTBR+zMQaG07J/btayQ=="
+		},
+		"node_modules/pug-lexer": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
+			"integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
+			"dependencies": {
+				"character-parser": "^2.2.0",
+				"is-expression": "^4.0.0",
+				"pug-error": "^2.0.0"
+			}
 		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
@@ -7181,6 +7416,22 @@
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"bin": {
 				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/set-function-length": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
+			"integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
+			"dependencies": {
+				"define-data-property": "^1.1.2",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.3",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -9445,6 +9696,14 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@prettier/plugin-pug": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@prettier/plugin-pug/-/plugin-pug-3.0.0.tgz",
+			"integrity": "sha512-ERMMvGSJK/7CTc8OT7W/dtlV43sytyNeiCWckN0DIFepqwXotU0+coKMv5Wx6IWSNj7ZSjdNGBAA1nMPi388xw==",
+			"requires": {
+				"pug-lexer": "^5.0.1"
+			}
+		},
 		"@prettier/plugin-xml": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.3.1.tgz",
@@ -10316,6 +10575,18 @@
 			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
 			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="
 		},
+		"call-bind": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+			"requires": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.1"
+			}
+		},
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -10368,6 +10639,14 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
 			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="
+		},
+		"character-parser": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
+			"integrity": "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==",
+			"requires": {
+				"is-regex": "^1.0.3"
+			}
 		},
 		"check-error": {
 			"version": "1.0.3",
@@ -10690,6 +10969,16 @@
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
 			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
 		},
+		"define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"requires": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			}
+		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -10764,6 +11053,19 @@
 			"requires": {
 				"is-arrayish": "^0.2.1"
 			}
+		},
+		"es-define-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+			"requires": {
+				"get-intrinsic": "^1.2.4"
+			}
+		},
+		"es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
 		},
 		"esbuild": {
 			"version": "0.19.12",
@@ -11135,9 +11437,9 @@
 			"optional": true
 		},
 		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
 		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
@@ -11158,6 +11460,18 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
 			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ=="
+		},
+		"get-intrinsic": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+			"requires": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
+			}
 		},
 		"get-package-type": {
 			"version": "0.1.0",
@@ -11266,6 +11580,14 @@
 				"slash": "^3.0.0"
 			}
 		},
+		"gopd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"requires": {
+				"get-intrinsic": "^1.1.3"
+			}
+		},
 		"graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -11293,6 +11615,40 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+		},
+		"has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"requires": {
+				"es-define-property": "^1.0.0"
+			}
+		},
+		"has-proto": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q=="
+		},
+		"has-symbols": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+		},
+		"has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"requires": {
+				"has-symbols": "^1.0.3"
+			}
+		},
+		"hasown": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
+			"integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
+			"requires": {
+				"function-bind": "^1.1.2"
+			}
 		},
 		"hosted-git-info": {
 			"version": "4.1.0",
@@ -11440,6 +11796,22 @@
 				"has": "^1.0.3"
 			}
 		},
+		"is-expression": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
+			"integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
+			"requires": {
+				"acorn": "^7.1.1",
+				"object-assign": "^4.1.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+					"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+				}
+			}
+		},
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -11487,6 +11859,15 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
 			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+		},
+		"is-regex": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			}
 		},
 		"is-stream": {
 			"version": "2.0.1",
@@ -12675,6 +13056,11 @@
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
 			"integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ=="
 		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -12885,6 +13271,21 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
 			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+		},
+		"pug-error": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz",
+			"integrity": "sha512-sjiUsi9M4RAGHktC1drQfCr5C5eriu24Lfbt4s+7SykztEOwVZtbFk1RRq0tzLxcMxMYTBR+zMQaG07J/btayQ=="
+		},
+		"pug-lexer": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
+			"integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
+			"requires": {
+				"character-parser": "^2.2.0",
+				"is-expression": "^4.0.0",
+				"pug-error": "^2.0.0"
+			}
 		},
 		"punycode": {
 			"version": "2.3.1",
@@ -13126,6 +13527,19 @@
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
+		},
+		"set-function-length": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
+			"integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
+			"requires": {
+				"define-data-property": "^1.1.2",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.3",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.1"
+			}
 		},
 		"shebang-command": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 	"dependencies": {
 		"@commitlint/cli": "18.6.1",
 		"@commitlint/config-conventional": "18.6.2",
+		"@prettier/plugin-pug": "3.0.0",
 		"@prettier/plugin-xml": "3.3.1",
 		"@swc/core": "1.4.2",
 		"@swc/jest": "0.2.36",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dr-devdeps",
-	"version": "0.14.0",
+	"version": "0.15.0",
 	"description": "",
 	"main": "index.js",
 	"scripts": {

--- a/src/jest.config.test.ts
+++ b/src/jest.config.test.ts
@@ -1,17 +1,6 @@
-import {dependsOn} from "./utils/dependsOn.js";
+import {dependsOnMock} from "./utils/dependsOn.mock.js";
 import {getRepoMetadata} from "./utils/getRepoMetadata.js";
 import {makeJestConfig} from "./jest.config.js";
-
-jest.mock("./utils/dependsOn.js", () => ({
-	dependsOn: jest.fn(),
-}));
-/**
- * Usage: Call `mockDependsOn.mockResolvedValue(false|true)` based on the array of dependencies that are passed in to
- * the function to determine the value of the `testEnvironment` variable in the jest.config.ts file. For example:
- * - Resolve to `true` to simulate `testEnvironment` as `jsdom` because frontend dependencies *are* installed.
- * - Resolve to `false` to simulate `testEnvironment` as `node` because frontend dependencies *are not* installed.
- * */
-const mockDependsOn = dependsOn as jest.MockedFunction<typeof dependsOn>;
 
 jest.mock("./utils/getRepoMetadata.js", () => ({
 	// Initialize the mock to return an empty object to prevent the following error from being thrown in the test run:
@@ -37,7 +26,7 @@ afterEach(() => {
 describe("the most important configuration options are correct", () => {
 	test("for the parts of the config that *are not* affected by conditional logic", async () => {
 		const hasFrontendDependencies = false;
-		mockDependsOn.mockResolvedValue(hasFrontendDependencies);
+		dependsOnMock.mockResolvedValue(hasFrontendDependencies);
 		mockGetRepoMetadata.mockReturnValue({
 			absoluteRootDir: "/Users/username/repos/dr-devdeps",
 			dependencyPartialPath: actualGetRepoMetadata().dependencyPartialPath,
@@ -46,7 +35,7 @@ describe("the most important configuration options are correct", () => {
 
 		const jestConfig = await makeJestConfig();
 
-		expect(mockDependsOn).toHaveBeenCalledWith(["pug", "react"]);
+		expect(dependsOnMock).toHaveBeenCalledWith(["pug", "react"]);
 		expect(typeof jestConfig).toEqual("object");
 		expect(jestConfig.coverageProvider).toEqual("v8");
 		expect(jestConfig.transform?.[".(js|jsx|ts|tsx)"]).toEqual("@swc/jest");
@@ -55,7 +44,7 @@ describe("the most important configuration options are correct", () => {
 
 	test("when testing this dr-devdeps repo (which *does not* have frontend dependencies)", async () => {
 		const hasFrontendDependencies = false;
-		mockDependsOn.mockResolvedValue(hasFrontendDependencies);
+		dependsOnMock.mockResolvedValue(hasFrontendDependencies);
 		mockGetRepoMetadata.mockReturnValue({
 			absoluteRootDir: "/Users/username/repos/dr-devdeps",
 			dependencyPartialPath: actualGetRepoMetadata().dependencyPartialPath,
@@ -74,8 +63,8 @@ describe("the most important configuration options are correct", () => {
 
 	test("when testing a repo that has installed the dr-devdeps package (repo *does* have frontend dependencies)", async () => {
 		const hasFrontendDependencies = true;
-		mockDependsOn.mockResolvedValue(hasFrontendDependencies);
-		mockDependsOn.mockResolvedValue(true);
+		dependsOnMock.mockResolvedValue(hasFrontendDependencies);
+		dependsOnMock.mockResolvedValue(true);
 		mockGetRepoMetadata.mockReturnValue({
 			absoluteRootDir: "/Users/username/repos/consuming-repo",
 			dependencyPartialPath: actualGetRepoMetadata().dependencyPartialPath,

--- a/src/jest.config.ts
+++ b/src/jest.config.ts
@@ -25,6 +25,7 @@ export const makeJestConfig = async (): Promise<Config> => {
 		"<rootDir>/lib/",
 		"<rootDir>/node_modules/",
 		"<rootDir>/www/",
+		".mock.ts",
 	] as const;
 
 	/**

--- a/src/prettier-plugins/pug.test.ts
+++ b/src/prettier-plugins/pug.test.ts
@@ -1,0 +1,23 @@
+import {pugPrettierPlugin} from "./pug.js";
+
+test("it has the correct types", () => {
+	expect(typeof pugPrettierPlugin).toEqual("object");
+	expect(typeof pugPrettierPlugin.config).toEqual("object");
+	expect(typeof pugPrettierPlugin.name).toEqual("string");
+});
+
+test("the configuration options and the plugin name are correct", () => {
+	expect(pugPrettierPlugin.config.pugAttributeSeparator).toEqual("as-needed");
+	expect(pugPrettierPlugin.config.pugClassLocation).toEqual(
+		"before-attributes",
+	);
+	expect(pugPrettierPlugin.config.pugClassNotation).toEqual("literal");
+	expect(pugPrettierPlugin.config.pugCommentPreserveSpaces).toEqual("keep-all");
+	expect(pugPrettierPlugin.config.pugEmptyAttributes).toEqual("as-is");
+	expect(pugPrettierPlugin.config.pugExplicitDiv).toBe(true);
+	expect(pugPrettierPlugin.config.pugIdNotation).toEqual("literal");
+	expect(pugPrettierPlugin.config.pugPreserveAttributeBrackets).toBe(false);
+	expect(pugPrettierPlugin.config.pugSortAttributes).toEqual("asc");
+	expect(pugPrettierPlugin.config.pugWrapAttributesThreshold).toEqual(-1);
+	expect(pugPrettierPlugin.name).toEqual("@prettier/plugin-pug");
+});

--- a/src/prettier-plugins/pug.ts
+++ b/src/prettier-plugins/pug.ts
@@ -1,0 +1,32 @@
+/** https://prettier.github.io/plugin-pug/guide/ */
+export const pugPrettierPlugin = {
+	config: {
+		// > Choose when to use commas to separate attributes in tags.
+		pugAttributeSeparator: "as-needed",
+		// > Define where classes will be placed.
+		// > `"before-attributes"` - Forces all valid class literals to be placed before attributes.
+		pugClassLocation: "before-attributes",
+		// > Define how classes should be formatted.
+		// > `"literal"` - Forces all valid classes to be printed as literals.
+		pugClassNotation: "literal",
+		// > Change behavior of spaces within comments.
+		pugCommentPreserveSpaces: "keep-all",
+		// > Change behavior of boolean attributes.
+		// > `"as-is"` - Nothing is changed.
+		pugEmptyAttributes: "as-is",
+		// > Define if a `div` tag should _always_ be printed with literal class and id formatting.
+		pugExplicitDiv: true,
+		// > Define how ids should be formatted.
+		// > `"literal"` - Forces all valid ids to be printed as literals.
+		pugIdNotation: "literal",
+		// > Define if brackets should be preserved while formatting attributes, even if empty.
+		pugPreserveAttributeBrackets: false,
+		// > Sort attributes that are not on _beginning_ and _end_ patterns.
+		// > `"asc"` - Sort attributes is ascending alphabetical order.
+		pugSortAttributes: "asc",
+		// > Define the maximum amount of attributes that an element can appear with on one line before it gets wrapped.
+		// > `-1` - Only wrap attributes as needed.
+		pugWrapAttributesThreshold: -1,
+	},
+	name: "@prettier/plugin-pug",
+} as const;

--- a/src/prettier-plugins/xml.test.ts
+++ b/src/prettier-plugins/xml.test.ts
@@ -6,7 +6,7 @@ test("it has the correct types", () => {
 	expect(typeof xmlPrettierPlugin.name).toEqual("string");
 });
 
-test("the most important configuration options and the plugin name are correct", () => {
+test("the configuration options and the plugin name are correct", () => {
 	expect(xmlPrettierPlugin.config.xmlQuoteAttributes).toEqual("double");
 	expect(xmlPrettierPlugin.config.xmlSelfClosingSpace).toBe(true);
 	expect(xmlPrettierPlugin.config.xmlSortAttributesByKey).toBe(true);

--- a/src/prettier.config.test.ts
+++ b/src/prettier.config.test.ts
@@ -1,10 +1,28 @@
-import prettierConfig from "./prettier.config.js";
+import {dependsOn} from "./utils/dependsOn.js";
+import {makePrettierConfig} from "./prettier.config.js";
+import {pugPrettierPlugin} from "./prettier-plugins/pug.js";
+import {xmlPrettierPlugin} from "./prettier-plugins/xml.js";
 
-test("it exports a configuration object", () => {
+jest.mock("./utils/dependsOn.js", () => ({
+	dependsOn: jest.fn(),
+}));
+/**
+ * Usage: Call `mockDependsOn.mockResolvedValue(false|true)` based on the array of dependencies that are passed in to
+ * the function to determine the value of the `hasPugDependency` variable in the prettier.config.ts file. For example:
+ * - Resolve to `true` to simulate that the `pug` package *is* installed as a dependency.
+ * - Resolve to `false` to simulate that the `pug` package *is not* installed as a dependency.
+ */
+const mockDependsOn = dependsOn as jest.MockedFunction<typeof dependsOn>;
+
+test("it exports a configuration object", async () => {
+	const prettierConfig = await makePrettierConfig();
+
 	expect(typeof prettierConfig).toEqual("object");
 });
 
-test("the most important configuration options are correct", () => {
+test("the most important configuration options are correct", async () => {
+	const prettierConfig = await makePrettierConfig();
+
 	expect(prettierConfig.endOfLine).toBeUndefined();
 	expect(prettierConfig.printWidth).toEqual(80);
 	expect(prettierConfig.proseWrap).toEqual("preserve");
@@ -13,10 +31,25 @@ test("the most important configuration options are correct", () => {
 	expect(prettierConfig.useTabs).toBe(true);
 });
 
-test("the XML plugin and configuration options are correct", () => {
-	expect(prettierConfig.plugins).toStrictEqual(["@prettier/plugin-xml"]);
-	expect(prettierConfig["xmlQuoteAttributes"]).toEqual("double");
-	expect(prettierConfig["xmlSelfClosingSpace"]).toBe(true);
-	expect(prettierConfig["xmlSortAttributesByKey"]).toBe(true);
-	expect(prettierConfig["xmlWhitespaceSensitivity"]).toEqual("ignore");
+describe("plugin names and configurations are correct for", () => {
+	test("the XML plugin", async () => {
+		const prettierConfig = await makePrettierConfig();
+
+		expect(prettierConfig.plugins).toStrictEqual(["@prettier/plugin-xml"]);
+		expect(prettierConfig).toEqual(
+			expect.objectContaining(xmlPrettierPlugin.config),
+		);
+	});
+
+	test("the Pug plugin", async () => {
+		const hasPugDependency = true;
+		mockDependsOn.mockResolvedValue(hasPugDependency);
+
+		const prettierConfig = await makePrettierConfig();
+
+		expect(prettierConfig.plugins).toContain("@prettier/plugin-pug");
+		expect(prettierConfig).toEqual(
+			expect.objectContaining(pugPrettierPlugin.config),
+		);
+	});
 });

--- a/src/prettier.config.test.ts
+++ b/src/prettier.config.test.ts
@@ -1,18 +1,7 @@
-import {dependsOn} from "./utils/dependsOn.js";
+import {dependsOnMock} from "./utils/dependsOn.mock.js";
 import {makePrettierConfig} from "./prettier.config.js";
 import {pugPrettierPlugin} from "./prettier-plugins/pug.js";
 import {xmlPrettierPlugin} from "./prettier-plugins/xml.js";
-
-jest.mock("./utils/dependsOn.js", () => ({
-	dependsOn: jest.fn(),
-}));
-/**
- * Usage: Call `mockDependsOn.mockResolvedValue(false|true)` based on the array of dependencies that are passed in to
- * the function to determine the value of the `hasPugDependency` variable in the prettier.config.ts file. For example:
- * - Resolve to `true` to simulate that the `pug` package *is* installed as a dependency.
- * - Resolve to `false` to simulate that the `pug` package *is not* installed as a dependency.
- */
-const mockDependsOn = dependsOn as jest.MockedFunction<typeof dependsOn>;
 
 test("it exports a configuration object", async () => {
 	const prettierConfig = await makePrettierConfig();
@@ -43,7 +32,7 @@ describe("plugin names and configurations are correct for", () => {
 
 	test("the Pug plugin", async () => {
 		const hasPugDependency = true;
-		mockDependsOn.mockResolvedValue(hasPugDependency);
+		dependsOnMock.mockResolvedValue(hasPugDependency);
 
 		const prettierConfig = await makePrettierConfig();
 

--- a/src/prettier.config.ts
+++ b/src/prettier.config.ts
@@ -1,61 +1,70 @@
 import {type Config} from "prettier";
+import {dependsOn} from "./utils/dependsOn.js";
+import {pugPrettierPlugin} from "./prettier-plugins/pug.js";
 import {xmlPrettierPlugin} from "./prettier-plugins/xml.js";
 
 /** https://prettier.io/docs/en/options.html */
-const prettierConfig: Config = {
-	arrowParens: "always",
-	bracketSameLine: false,
-	bracketSpacing: false,
-	// Excerpt from https://prettier.io/docs/en/options.html#embedded-language-formatting:
-	// > When Prettier identifies cases where it looks like you've placed some code it knows how to format
-	// > within a string in another file, like in a tagged template in JavaScript with a tag named `html`
-	// > or in code blocks in Markdown, it will by default try to format that code.
-	embeddedLanguageFormatting: "auto",
-	// Refer to .gitattributes file for the rationale of leaving `endOfLine` unset.
-	// endOfLine
-	//
-	// Excerpt from https://prettier.io/blog/2018/11/07/1.15.0.html#whitespace-sensitive-formatting:
-	// > Whitespace is significant in HTML inline elements.
-	// > For this reason, we cannot safely format some HTML code since it may modify the displayed output in the browser.
-	// > Instead of breaking your code or just doing nothing, we introduce _whitespace-sensitive formatting_, which:
-	// > - follows the default CSS `display` value for every element to identify if the whitespace inside it is significant,
-	// > - and wraps the tags in such a way as to avoid adding or removing significant whitespace.
-	// > We also allow magic comments (e.g., `<!-- display: block -->`) to tell Prettier
-	// > how to format elements due to the fact that CSS display can be changed.
-	htmlWhitespaceSensitivity: "css",
-	jsxSingleQuote: false,
-	// Excerpt from https://prettier.io/docs/en/options.html#print-width:
-	// > Specify the line length that the printer will wrap on.
-	// > **For readability we recommend against using more than 80 characters.**
-	// > Prettier's `printWidth` option [...] is not the hard upper allowed line length limit.
-	// > It is a way to say to Prettier roughly how long you'd like lines to be.
-	// > Prettier will make both shorter and longer lines, but generally strive to meet the specified `printWidth`.
-	printWidth: 80,
-	// Don't wrap lines when formatting text in Markdown files since some services use a linebreak-sensitive renderer, e.g. GitHub comments.
-	proseWrap: "preserve",
-	quoteProps: "as-needed",
-	semi: true,
-	singleAttributePerLine: false,
-	// Prefer double quotes for strings because single quotes are used more often
-	// within sentences for contractions and to indicate possession. Examples:
-	// - Contraction: "It's a personal preference."
-	// - Possession: "This is Dustin's codebase."
-	// Excerpt from https://prettier.io/docs/en/options.html#quotes:
-	// > If the number of quotes outweighs the other quote, the quote which is less used will be used to format the string. Examples:
-	// > - "I'm double quoted" will result in in "I'm double quoted".
-	// > - "This \"example\" is single quoted" will result in 'This "example" is single quoted'.
-	singleQuote: false,
-	tabWidth: 2,
-	// Add trailing commas wherever possible to help reduce the number of changed lines when viewing Git diffs.
-	trailingComma: "all",
-	// Refer to .editorconfig file for the rationale of choosing to indent lines with tabs instead of spaces.
-	useTabs: true,
-	// Prettier plugins.
-	plugins: [
-		// SVG files use XML syntax, so use the XML plugin to check/autoformat them.
-		xmlPrettierPlugin.name,
-	],
-	...xmlPrettierPlugin.config,
+export const makePrettierConfig = async (): Promise<Config> => {
+	const hasPugDependency = await dependsOn(["pug"]);
+
+	return {
+		arrowParens: "always",
+		bracketSameLine: false,
+		bracketSpacing: false,
+		// Excerpt from https://prettier.io/docs/en/options.html#embedded-language-formatting:
+		// > When Prettier identifies cases where it looks like you've placed some code it knows how to format
+		// > within a string in another file, like in a tagged template in JavaScript with a tag named `html`
+		// > or in code blocks in Markdown, it will by default try to format that code.
+		embeddedLanguageFormatting: "auto",
+		// Refer to .gitattributes file for the rationale of leaving `endOfLine` unset.
+		// endOfLine
+		//
+		// Excerpt from https://prettier.io/blog/2018/11/07/1.15.0.html#whitespace-sensitive-formatting:
+		// > Whitespace is significant in HTML inline elements.
+		// > For this reason, we cannot safely format some HTML code since it may modify the displayed output in the browser.
+		// > Instead of breaking your code or just doing nothing, we introduce _whitespace-sensitive formatting_, which:
+		// > - follows the default CSS `display` value for every element to identify if the whitespace inside it is significant,
+		// > - and wraps the tags in such a way as to avoid adding or removing significant whitespace.
+		// > We also allow magic comments (e.g., `<!-- display: block -->`) to tell Prettier
+		// > how to format elements due to the fact that CSS display can be changed.
+		htmlWhitespaceSensitivity: "css",
+		jsxSingleQuote: false,
+		// Excerpt from https://prettier.io/docs/en/options.html#print-width:
+		// > Specify the line length that the printer will wrap on.
+		// > **For readability we recommend against using more than 80 characters.**
+		// > Prettier's `printWidth` option [...] is not the hard upper allowed line length limit.
+		// > It is a way to say to Prettier roughly how long you'd like lines to be.
+		// > Prettier will make both shorter and longer lines, but generally strive to meet the specified `printWidth`.
+		printWidth: 80,
+		// Don't wrap lines when formatting text in Markdown files since some services use a linebreak-sensitive renderer, e.g. GitHub comments.
+		proseWrap: "preserve",
+		quoteProps: "as-needed",
+		semi: true,
+		singleAttributePerLine: false,
+		// Prefer double quotes for strings because single quotes are used more often
+		// within sentences for contractions and to indicate possession. Examples:
+		// - Contraction: "It's a personal preference."
+		// - Possession: "This is Dustin's codebase."
+		// Excerpt from https://prettier.io/docs/en/options.html#quotes:
+		// > If the number of quotes outweighs the other quote, the quote which is less used will be used to format the string. Examples:
+		// > - "I'm double quoted" will result in in "I'm double quoted".
+		// > - "This \"example\" is single quoted" will result in 'This "example" is single quoted'.
+		singleQuote: false,
+		tabWidth: 2,
+		// Add trailing commas wherever possible to help reduce the number of changed lines when viewing Git diffs.
+		trailingComma: "all",
+		// Refer to .editorconfig file for the rationale of choosing to indent lines with tabs instead of spaces.
+		useTabs: true,
+		// Configure the Prettier plugins.
+		plugins: [
+			// SVG files use XML syntax, so use the corresponding plugin to check and autoformat them.
+			xmlPrettierPlugin.name,
+			// Conditionally include the Pug plugin in the configuration if the consuming repository has a dependency on the `pug` package.
+			...(hasPugDependency ? [pugPrettierPlugin.name] : []),
+		],
+		...xmlPrettierPlugin.config,
+		...(hasPugDependency ? pugPrettierPlugin.config : {}),
+	};
 };
 
-export default prettierConfig;
+export default makePrettierConfig();

--- a/src/utils/dependsOn.mock.ts
+++ b/src/utils/dependsOn.mock.ts
@@ -1,0 +1,21 @@
+import {dependsOn} from "./dependsOn.js";
+
+jest.mock("./dependsOn.js", () => ({
+	dependsOn: jest.fn(),
+}));
+
+/**
+ * Call `dependsOnMock.mockResolvedValue(false|true)` based on the array of dependencies that are passed in to the `dependsOn` function.
+ *
+ * @example
+ * ```
+ * // The following line of code checks the repository's package.json file to determine
+ * // whether or not the project depends on either the Pug or React packages.
+ * const testEnvironment = await dependsOn(["pug", "react"]) ? "jsdom" : "node";
+ *
+ * // Use the mocked implementation of `dependsOn` by resolving its promise to the value needed for the test.
+ * const doesDependOnFrontendPackages = dependsOnMock.mockResolvedValue(true)
+ * const doesNotDependOnFrontendPackages = dependsOnMock.mockResolvedValue(false)
+ * ```
+ * */
+export const dependsOnMock = dependsOn as jest.MockedFunction<typeof dependsOn>;


### PR DESCRIPTION
Summary of changes:

- Install `@prettier/plugin-pug` as a dependency and configure it.
- Implement `makePrettierConfig` function to simplify testing the conditional logic of the configuration object.
- Replace repeated per-file mocks of `dependsOn` with a reusable mock function.
- Manually bump the package.json version number to `0.15.0`.
